### PR TITLE
Some more tweaks!

### DIFF
--- a/packages/google_adsense/README.md
+++ b/packages/google_adsense/README.md
@@ -24,7 +24,7 @@ To start displaying ads, initialize the AdSense with your [client/publisher ID](
 import 'package:google_adsense/google_adsense.dart';
 
 void main() {
-  adSense.initialize('your_ad_client_id');
+  adSense.initialize('0556581589806023'); // TODO: Replace with your own AdClient ID
   runApp(const MyApp());
 }
 
@@ -33,10 +33,11 @@ You are all set to start displaying [Auto ads](https://support.google.com/adsens
 #### Display ad unit Widget
 <?code-excerpt "example/lib/main.dart (adUnit)"?>
 ```dart
-adSense.adUnit(AdUnitConfiguration.displayAdUnit(
-    adSlot: 'your_ad_slot_id',
-    adFormat: AdFormat.AUTO,
-    isFullWidthResponsive: false))
+    adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+  adSlot: '4773943862', // TODO: Replace with your own AdSlot ID
+  adFormat: AdFormat
+      .AUTO, // Remove AdFormat to make ads limited by height
+))
 ```
 
 #### Customize ad unit Widget

--- a/packages/google_adsense/example/integration_test/ad_widget_test.dart
+++ b/packages/google_adsense/example/integration_test/ad_widget_test.dart
@@ -6,68 +6,161 @@
 // 1. Run chrome driver with --port=4444
 // 2. Run the test from example folder with: flutter drive -d web-server --web-port 7357 --browser-name chrome --driver test_driver/integration_test.dart --target integration_test/ad_widget_test.dart
 
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:google_adsense/google_adsense.dart';
+// Ensure we don't use the singleton `adSense`, but the local copies to this plugin.
+import 'package:google_adsense/google_adsense.dart' hide adSense;
 import 'package:integration_test/integration_test.dart';
 import 'package:web/web.dart' as web;
 
+import 'test_js_interop.dart';
+
 const String testClient = 'test_client';
 const String testSlot = 'test_slot';
-late AdSense adsense;
+const String testScriptUrl =
+    'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-$testClient';
 
 void main() async {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  late AdSense adsense;
 
   setUp(() async {
     adsense = AdSense();
   });
 
+  tearDown(() {
+    clearAdsByGoogleMock();
+  });
+
   group('initialization', () {
-    testWidgets('Initialization adds AdSense snippet to index.html',
-        (WidgetTester _) async {
+    testWidgets('Initialization adds AdSense snippet.', (WidgetTester _) async {
+      final web.HTMLElement target = web.HTMLDivElement();
       // Given
-      const String expectedScriptUrl =
-          'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-$testClient';
 
-      // When
-      adsense.initialize(testClient);
+      adsense.initialize(testClient, jsLoaderTarget: target);
 
-      // Then
-      final web.HTMLScriptElement injected =
-          web.document.head!.lastChild! as web.HTMLScriptElement;
-      expect(injected.src, expectedScriptUrl);
+      final web.HTMLScriptElement? injected =
+          target.lastElementChild as web.HTMLScriptElement?;
+
+      expect(injected, isNotNull);
+      expect(injected!.src, testScriptUrl);
       expect(injected.crossOrigin, 'anonymous');
       expect(injected.async, true);
+    });
+
+    testWidgets('Skips initialization if script already present.',
+        (WidgetTester _) async {
+      final web.HTMLScriptElement script = web.HTMLScriptElement()
+        ..id = 'previously-injected'
+        ..src = testScriptUrl;
+      final web.HTMLElement target = web.HTMLDivElement()..appendChild(script);
+
+      adsense.initialize(testClient, jsLoaderTarget: target);
+
+      expect(target.childElementCount, 1);
+      expect(target.firstElementChild?.id, 'previously-injected');
+    });
+
+    testWidgets('Skips initialization if adsense object already present.',
+        (WidgetTester _) async {
+      final web.HTMLElement target = web.HTMLDivElement();
+
+      // Write an empty noop object
+      mockAdsByGoogle(() {});
+
+      adsense.initialize(testClient, jsLoaderTarget: target);
+
+      expect(target.firstElementChild, isNull);
     });
   });
 
   group('adWidget', () {
-    testWidgets('AdUnitWidget is created and rendered',
+    testWidgets('Filled ad units resize widget height',
         (WidgetTester tester) async {
       // When
-      // TODO(sokoloff06): Mock server response
+      mockAdsByGoogle(() {
+        // Locate the target element, and push a red div to it...
+        final web.Element? adTarget =
+            web.document.querySelector('div[id^=adUnit] ins');
+
+        final web.HTMLElement fakeAd = web.HTMLDivElement()
+          ..style.width = '320px'
+          ..style.height = '137px'
+          ..style.background = 'red';
+
+        adTarget!
+          ..appendChild(fakeAd)
+          ..setAttribute('data-ad-status', AdStatus.FILLED);
+      });
 
       adsense.initialize(testClient);
+
       final Widget adUnitWidget =
-          adSense.adUnit(AdUnitConfiguration.displayAdUnit(adSlot: testSlot));
-      await tester.pumpWidget(adUnitWidget);
-      await tester.pumpWidget(
-          adUnitWidget); // TODO(sokoloff06): Why only works when pumping twice?
+          adsense.adUnit(AdUnitConfiguration.displayAdUnit(adSlot: testSlot));
+
+      await pumpAdWidget(adUnitWidget, tester);
+
       // Then
       // Widget level
       expect(find.byWidget(adUnitWidget), findsOneWidget);
-      expect(adUnitWidget, isA<Widget>());
 
-      // DOM level
-      final web.HTMLElement? platformView =
-          web.document.querySelector('flt-platform-view') as web.HTMLElement?;
-      expect(platformView, isNotNull);
-      final web.HTMLElement ins =
-          platformView!.querySelector('ins')! as web.HTMLElement;
-      expect(ins.style.display, 'block');
+      final Size size = tester.getSize(find.byWidget(adUnitWidget));
 
-      // TODO(sokoloff06): Validate response is rendered
+      expect(size.height, 137);
+    });
+
+    testWidgets('Unfilled ad units collapse widget height',
+        (WidgetTester tester) async {
+      // When
+      mockAdsByGoogle(() {
+        // Locate the target element, and push a red div to it...
+        final web.Element? adTarget =
+            web.document.querySelector('div[id^=adUnit] ins');
+
+        // The internal styling of the Ad doesn't matter, if AdSense tells us it is UNFILLED.
+        final web.HTMLElement fakeAd = web.HTMLDivElement()
+          ..style.width = '320px'
+          ..style.height = '137px'
+          ..style.background = 'red';
+
+        adTarget!
+          ..appendChild(fakeAd)
+          ..setAttribute('data-ad-status', AdStatus.UNFILLED);
+      });
+
+      adsense.initialize(testClient);
+      final Widget adUnitWidget =
+          adsense.adUnit(AdUnitConfiguration.displayAdUnit(adSlot: testSlot));
+
+      await pumpAdWidget(adUnitWidget, tester);
+
+      // Then
+      // Widget level
+      expect(find.byWidget(adUnitWidget), findsOneWidget);
+
+      final Size size = tester.getSize(find.byWidget(adUnitWidget));
+
+      expect(size.height, 0);
     });
   });
+}
+
+// Pumps an AdUnit Widget into a given tester, with some parameters
+Future<void> pumpAdWidget(Widget adUnit, WidgetTester tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: adUnit,
+        ),
+      ),
+    ),
+  );
+
+  // This extra pump is needed for the platform view to actually render in the DOM.
+  await tester.pump();
+
+  // This extra pump is needed to simulate the async behavior of the adsense JS mock.
+  await tester.pumpAndSettle();
 }

--- a/packages/google_adsense/example/integration_test/script_tag_test.dart
+++ b/packages/google_adsense/example/integration_test/script_tag_test.dart
@@ -1,0 +1,37 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_adsense/google_adsense.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:web/web.dart' as web;
+
+const String testClient = 'test_client';
+
+void main() async {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  // We test this separately so we don't have to worry about removing the script
+  // from the page. Tests in `ad_widget_test.dart` use overrides in `initialize`
+  // to keep them self-contained.
+  group('JS initialization', () {
+    testWidgets('Initialization adds AdSense snippet.', (WidgetTester _) async {
+      // Given
+      const String expectedScriptUrl =
+          'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-$testClient';
+
+      // When (using the singleton adSense from the plugin)
+      adSense.initialize(testClient);
+
+      // Then
+      final web.HTMLScriptElement? injected =
+          web.document.head?.lastElementChild as web.HTMLScriptElement?;
+
+      expect(injected, isNotNull);
+      expect(injected!.src, expectedScriptUrl);
+      expect(injected.crossOrigin, 'anonymous');
+      expect(injected.async, true);
+    });
+  });
+}

--- a/packages/google_adsense/example/integration_test/test_js_interop.dart
+++ b/packages/google_adsense/example/integration_test/test_js_interop.dart
@@ -1,0 +1,29 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+@JS()
+library;
+
+import 'dart:async';
+import 'dart:js_interop';
+
+// window.adsbygoogle uses "duck typing", so let us set anything to it.
+@JS('adsbygoogle')
+external set _adsbygoogle(JSAny? value);
+
+/// Mocks `adsbygoogle` [push] function.
+///
+/// `push` will run in the next tick (`Timer.run`) to ensure async behavior.
+void mockAdsByGoogle(void Function() push) {
+  _adsbygoogle = <String, Object>{
+    'push': () {
+      Timer.run(push);
+    }.toJS,
+  }.jsify();
+}
+
+/// Sets `adsbygoogle` to null.
+void clearAdsByGoogleMock() {
+  _adsbygoogle = null;
+}

--- a/packages/google_adsense/example/lib/main.dart
+++ b/packages/google_adsense/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:google_adsense/google_adsense.dart';
 
 void main() {
-  adSense.initialize('your_ad_client_id');
+  adSense.initialize('0556581589806023');
   runApp(const MyApp());
 }
 
@@ -63,21 +63,24 @@ class _MyHomePageState extends State<MyHomePage> {
             const Text(
               'You have pushed the button this many times:',
             ),
-            Row(
-              children: <Widget>[
-                const Text('Some text'),
-                Expanded(
-                  child:
-                      // #docregion adUnit
-                      adSense.adUnit(AdUnitConfiguration.displayAdUnit(
-                          adSlot: 'your_ad_slot_id',
-                          adFormat: AdFormat.AUTO,
-                          isFullWidthResponsive: false))
-                  // #enddocregion adUnit
-                  ,
-                )
-              ],
+            // #docregion adUnit
+            // Responsive ad example
+            Container(
+              child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+                  adSlot: '4773943862',
+                  adFormat: AdFormat.AUTO, // Remove AdFormat to make ads limited by height
+                  isFullWidthResponsive: false)),
             ),
+            // Fixed size ad example
+            SizedBox(
+              height: 125,
+              width: 125,
+              child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+                  adSlot: '8937810400',
+                  // adFormat: AdFormat.AUTO, // Not using AdFormat to make ads limited by height
+                  isFullWidthResponsive: false)),
+            ),
+            // #enddocregion adUnit
             Text(
               '$_counter',
               style: Theme.of(context).textTheme.headlineMedium,

--- a/packages/google_adsense/example/lib/main.dart
+++ b/packages/google_adsense/example/lib/main.dart
@@ -8,7 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:google_adsense/google_adsense.dart';
 
 void main() {
-  adSense.initialize('0556581589806023');
+  adSense.initialize('0556581589806023'); // TODO: Replace with your own AdClient ID
   runApp(const MyApp());
 }
 
@@ -56,43 +56,54 @@ class _MyHomePageState extends State<MyHomePage> {
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
         title: const Text('AdSense for Flutter demo app'),
       ),
-      body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-            const Text(
-              'You have pushed the button this many times:',
-            ),
-            // #docregion adUnit
-            // Responsive ad example
-            Container(
-              child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
-                  adSlot: '4773943862',
-                  adFormat: AdFormat.AUTO, // Remove AdFormat to make ads limited by height
-                  isFullWidthResponsive: false)),
-            ),
-            // Fixed size ad example
-            SizedBox(
-              height: 125,
-              width: 125,
-              child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
-                  adSlot: '8937810400',
-                  // adFormat: AdFormat.AUTO, // Not using AdFormat to make ads limited by height
-                  isFullWidthResponsive: false)),
-            ),
-            // #enddocregion adUnit
-            Text(
-              '$_counter',
-              style: Theme.of(context).textTheme.headlineMedium,
-            ),
-          ],
+      body: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              const Text(
+                'Responsive Ad Constrained by width of 150px:',
+              ),
+              Container(
+                constraints: const BoxConstraints(maxWidth: 150),
+                padding: const EdgeInsets.only(bottom: 10),
+                child:
+                    // #docregion adUnit
+                    adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+                  adSlot: '4773943862', // TODO: Replace with your own AdSlot ID
+                  adFormat: AdFormat
+                      .AUTO, // Remove AdFormat to make ads limited by height
+                ))
+                // #enddocregion adUnit
+                ,
+              ),
+              const Text(
+                'Responsive Ad Constrained by height of 100px:',
+              ),
+              Container(
+                constraints: const BoxConstraints(maxHeight: 100),
+                padding: const EdgeInsets.only(bottom: 10),
+                child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+                  adSlot: '4773943862', // TODO: Replace with your own AdSlot ID
+                  // adFormat: AdFormat.AUTO, // Not using AdFormat to make ad unit respect height constraint
+                )),
+              ),
+              const Text(
+                'Fixed 125x125 size Ad:',
+              ),
+              Container(
+                height: 125,
+                width: 125,
+                padding: const EdgeInsets.only(bottom: 10),
+                child: adSense.adUnit(AdUnitConfiguration.displayAdUnit(
+                    adSlot: '8937810400',
+                    // adFormat: AdFormat.AUTO, // Not using AdFormat to make ad unit respect height constraint
+                    isFullWidthResponsive: false)),
+              ),
+            ],
+          ),
         ),
       ),
-      floatingActionButton: FloatingActionButton(
-        onPressed: _incrementCounter,
-        tooltip: 'Increment',
-        child: const Icon(Icons.add),
-      ), // This trailing comma makes auto-formatting nicer for build methods.
     );
   }
 }

--- a/packages/google_adsense/lib/google_adsense.dart
+++ b/packages/google_adsense/lib/google_adsense.dart
@@ -3,4 +3,5 @@
 // found in the LICENSE file.
 export 'src/ad_unit_configuration.dart';
 export 'src/ad_unit_params.dart';
-export 'src/adsense_stub.dart' if (dart.library.html) 'src/adsense_web.dart';
+export 'src/adsense_stub.dart'
+    if (dart.library.js_interop) 'src/adsense_web.dart';

--- a/packages/google_adsense/lib/src/ad_unit_configuration.dart
+++ b/packages/google_adsense/lib/src/ad_unit_configuration.dart
@@ -109,9 +109,6 @@ class AdUnitConfiguration {
   /// See [AdUnitParams.AD_TEST]
   final bool isAdTest;
 
-  /// See [AdUnitParams.AD_CLIENT]
-  String get adClient => _adUnitParams[AdUnitParams.AD_CLIENT]!;
-
   /// See [AdUnitParams.AD_SLOT]
   String get adSlot => _adUnitParams[AdUnitParams.AD_SLOT]!;
 

--- a/packages/google_adsense/lib/src/ad_unit_configuration.dart
+++ b/packages/google_adsense/lib/src/ad_unit_configuration.dart
@@ -28,7 +28,7 @@ class AdUnitConfiguration {
     int? rowsNum,
     int? columnsNum,
     bool? isFullWidthResponsive = true,
-    this.isAdTest = kDebugMode,
+    bool? isAdTest,
   }) : _adUnitParams = <String, String>{
           AdUnitParams.AD_SLOT: adSlot,
           if (adFormat != null) AdUnitParams.AD_FORMAT: adFormat.toString(),
@@ -44,6 +44,7 @@ class AdUnitConfiguration {
             AdUnitParams.MATCHED_CONTENT_COLUMNS_NUM: columnsNum.toString(),
           if (rowsNum != null)
             AdUnitParams.MATCHED_CONTENT_ROWS_NUM: rowsNum.toString(),
+          if (isAdTest != null && isAdTest) AdUnitParams.AD_TEST: 'on',
         };
 
   /// Creates In-article ad unit configuration object
@@ -105,12 +106,6 @@ class AdUnitConfiguration {
             isAdTest: isAdTest);
 
   Map<String, String> _adUnitParams;
-
-  /// See [AdUnitParams.AD_TEST]
-  final bool isAdTest;
-
-  /// See [AdUnitParams.AD_SLOT]
-  String get adSlot => _adUnitParams[AdUnitParams.AD_SLOT]!;
 
   /// Map containing all additional parameters of this configuration
   Map<String, String> get params => _adUnitParams;

--- a/packages/google_adsense/lib/src/ad_unit_widget.dart
+++ b/packages/google_adsense/lib/src/ad_unit_widget.dart
@@ -15,10 +15,12 @@ import 'js_interop/adsbygoogle.dart';
 /// Widget displaying an ad unit
 class AdUnitWidget extends StatefulWidget {
   /// Constructs [AdUnitWidget]
-  AdUnitWidget._internal({
+  AdUnitWidget._internal(
+    String adClient, {
     required bool isAdTest,
     required Map<String, String> unitParams,
-  })  : _isAdTest = isAdTest,
+  })  : _adClient = adClient,
+        _isAdTest = isAdTest,
         _unitParams = unitParams {
     final Map<String, String> dataAttrs = <String, String>{
       AdUnitParams.AD_CLIENT: 'ca-pub-$_adClient',
@@ -31,11 +33,11 @@ class AdUnitWidget extends StatefulWidget {
   }
 
   /// Creates [AdUnitWidget] from [AdUnitConfiguration] object
-  AdUnitWidget.fromConfig(AdUnitConfiguration unitConfig)
-      : this._internal(
+  AdUnitWidget.fromConfig(String adClient, AdUnitConfiguration unitConfig)
+      : this._internal(adClient,
             isAdTest: unitConfig.isAdTest, unitParams: unitConfig.params);
 
-  final String _adClient = adSense.adClient;
+  final String _adClient;
 
   final bool _isAdTest;
 

--- a/packages/google_adsense/lib/src/ad_unit_widget.dart
+++ b/packages/google_adsense/lib/src/ad_unit_widget.dart
@@ -88,10 +88,6 @@ class _AdUnitWidgetWebState extends State<AdUnitWidget>
     final web.HTMLElement insElement =
         (web.document.createElement('ins') as web.HTMLElement)
           ..className = 'adsbygoogle'
-          ..style.width = '100%'
-          ..style.height = '100%'
-          ..style.maxWidth = '${_constraints.maxWidth}px'
-          ..style.height = '${_constraints.maxHeight}px'
           ..style.display = 'block';
 
     // Apply the widget configuration to insElement
@@ -125,8 +121,10 @@ class _AdUnitWidgetWebState extends State<AdUnitWidget>
             ));
           } else {
             // Prevent scrolling issues over empty ad slot
-            target.style.pointerEvents = 'none';
-            target.style.height = '0px';
+            target
+              ..style.pointerEvents = 'none'
+              ..style.height = '0px'
+              ..style.width = '0px';
             _updateWidgetSize(Size.zero);
           }
         }

--- a/packages/google_adsense/lib/src/adsense_stub.dart
+++ b/packages/google_adsense/lib/src/adsense_stub.dart
@@ -11,13 +11,15 @@ final AdSense adSense = AdSense();
 
 /// Main class to work with the library
 class AdSense {
-  final String _adClient = '';
-
   /// Getter for adClient passed on initialization
-  String get adClient => _adClient;
+  late String adClientId;
 
   /// Initialization API. Should be called ASAP, ideally in the main method of your app.
-  void initialize(String adClient) {
+  void initialize(
+    String adClient, {
+    @visibleForTesting bool skipJsLoader = false,
+    @visibleForTesting Object? jsLoaderTarget,
+  }) {
     throw UnsupportedError('Only supported on web');
   }
 

--- a/packages/google_adsense/lib/src/adsense_stub.dart
+++ b/packages/google_adsense/lib/src/adsense_stub.dart
@@ -6,14 +6,11 @@ import 'package:flutter/widgets.dart';
 
 import '../google_adsense.dart';
 
-/// Returns a singleton instance of Adsense library public interface
+/// A singleton instance of AdSense library public interface.
 final AdSense adSense = AdSense();
 
-/// Main class to work with the library
+/// AdSense package interface.
 class AdSense {
-  /// Getter for adClient passed on initialization
-  late String adClientId;
-
   /// Initialization API. Should be called ASAP, ideally in the main method of your app.
   void initialize(
     String adClient, {

--- a/packages/google_adsense/lib/src/adsense_web.dart
+++ b/packages/google_adsense/lib/src/adsense_web.dart
@@ -12,6 +12,8 @@ import 'ad_unit_widget.dart';
 import 'js_interop/adsbygoogle.dart' show adsbygooglePresent;
 import 'js_interop/package_web_tweaks.dart';
 
+import 'logging.dart';
+
 /// Returns a singleton instance of Adsense library public interface
 final AdSense adSense = AdSense();
 
@@ -35,15 +37,14 @@ class AdSense {
     @visibleForTesting web.HTMLElement? jsLoaderTarget,
   }) {
     if (_isInitialized) {
-      web.console.warn(
-          'AdSense: adSense.initialize called multiple times! Skipping.'.toJS);
+      debugLog('adSense.initialize called multiple times. Skipping init.');
       return;
     }
     adClientId = adClient;
     if (!(skipJsLoader || _sdkAlreadyLoaded(testingTarget: jsLoaderTarget))) {
       _loadJsSdk(adClientId, jsLoaderTarget);
     } else {
-      web.console.debug('AdSense: SDK already on page, skipping'.toJS);
+      debugLog('SDK already on page. Skipping init.');
     }
     _isInitialized = true;
   }
@@ -71,9 +72,6 @@ class AdSense {
 
     if (web.window.nullableTrustedTypes != null) {
       final String trustedTypePolicyName = 'adsense-dart-$adClient';
-      web.console.debug(
-        'TrustedTypes available. Creating policy: $trustedTypePolicyName'.toJS,
-      );
       try {
         final web.TrustedTypePolicy policy =
             web.window.trustedTypes.createPolicy(
@@ -86,6 +84,7 @@ class AdSense {
         throw TrustedTypesException(e.toString());
       }
     } else {
+      debugLog('TrustedTypes not available.');
       script.src = finalUrl;
     }
 

--- a/packages/google_adsense/lib/src/adsense_web.dart
+++ b/packages/google_adsense/lib/src/adsense_web.dart
@@ -51,7 +51,7 @@ class AdSense {
 
   /// Returns an [AdUnitWidget] with the specified [configuration].
   Widget adUnit(AdUnitConfiguration configuration) {
-    return AdUnitWidget.fromConfig(_adClient, configuration);
+    return AdUnitWidget(adClient: _adClient, configuration: configuration);
   }
 
   bool _sdkAlreadyLoaded({

--- a/packages/google_adsense/lib/src/adsense_web.dart
+++ b/packages/google_adsense/lib/src/adsense_web.dart
@@ -22,7 +22,7 @@ class AdSense {
   bool _isInitialized = false;
 
   /// The ad client ID used by this client.
-  late String adClientId;
+  late String _adClient;
   static const String _url =
       'https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-';
 
@@ -40,9 +40,9 @@ class AdSense {
       debugLog('adSense.initialize called multiple times. Skipping init.');
       return;
     }
-    adClientId = adClient;
+    _adClient = adClient;
     if (!(skipJsLoader || _sdkAlreadyLoaded(testingTarget: jsLoaderTarget))) {
-      _loadJsSdk(adClientId, jsLoaderTarget);
+      _loadJsSdk(_adClient, jsLoaderTarget);
     } else {
       debugLog('SDK already on page. Skipping init.');
     }
@@ -51,13 +51,13 @@ class AdSense {
 
   /// Returns an [AdUnitWidget] with the specified [configuration].
   Widget adUnit(AdUnitConfiguration configuration) {
-    return AdUnitWidget.fromConfig(adClientId, configuration);
+    return AdUnitWidget.fromConfig(_adClient, configuration);
   }
 
   bool _sdkAlreadyLoaded({
     web.HTMLElement? testingTarget,
   }) {
-    final String selector = 'script[src*=ca-pub-$adClientId]';
+    final String selector = 'script[src*=ca-pub-$_adClient]';
     return adsbygooglePresent ||
         web.document.querySelector(selector) != null ||
         testingTarget?.querySelector(selector) != null;

--- a/packages/google_adsense/lib/src/js_interop/adsbygoogle.dart
+++ b/packages/google_adsense/lib/src/js_interop/adsbygoogle.dart
@@ -29,11 +29,14 @@ external AdsByGoogle? get _adsbygoogle;
 @JS('adsbygoogle')
 external set _adsbygoogle(JSAny? value);
 
+/// Whether or not the `window.adsbygoogle` object is defined and not null.
+bool get adsbygooglePresent => _adsbygoogle.isDefinedAndNotNull;
+
 /// Binding to the `adsbygoogle` JS global.
 ///
 /// See: https://support.google.com/adsense/answer/9274516?hl=en&ref_topic=28893&sjid=11495822575537499409-EU
 AdsByGoogle get adsbygoogle {
-  if (_adsbygoogle.isUndefinedOrNull) {
+  if (!adsbygooglePresent) {
     // Initialize _adsbygoole to "something that has a push method".
     _adsbygoogle = JSArray<JSObject>();
   }

--- a/packages/google_adsense/lib/src/logging.dart
+++ b/packages/google_adsense/lib/src/logging.dart
@@ -1,0 +1,15 @@
+// Copyright 2013 The Flutter Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:js_interop';
+
+import 'package:flutter/foundation.dart' show kDebugMode;
+import 'package:web/web.dart' as web;
+
+/// Logs [log] to the JS console with debug level, if [kDebugMode] is `true`.
+void debugLog(String log) {
+  if (kDebugMode) {
+    web.console.debug('[google_adsense] $log'.toJS);
+  }
+}


### PR DESCRIPTION
Some more tweaks to the package, mainly:

* Add integration tests for the loader + widget rendering, trying to mock the AdSense behavior.
  * Add some extra `visibleForTesting` parameters to initialize so the `AdSense()` instance is self-contained (`skipJsLoader`, `jsLoaderTarget`).
  * (There's a test that actually lets the script inject the script tag into the page, but the rest should be self-contained).
* Tweak the conditional export to be compatible with Wasm (tests pass!)
* Removed `adClient` from `AdConfiguration`, and ensure we use the one configured in the `AdSense` instance, instead of accessing the global singleton value.
  * Actually, I removed adClient from AdConfig as well, since we use whatever was set on initialize.
* Unified the logging code so we only log if `kDebugMode` and always as `console.debug`.
* Simplified some other code around the logging.
* Made most methods private.
* Ensure the widget only sizes its height, leaving the width as unset.
* Return an empty 0x0 widget if ad is unfilled

