### PR TITLE
Update tests to match AdSense behavior, and our code.

### DIFF
--- a/packages/google_adsense/example/integration_test/test_js_interop.dart
+++ b/packages/google_adsense/example/integration_test/test_js_interop.dart
@@ -7,6 +7,12 @@ library;
 
 import 'dart:async';
 import 'dart:js_interop';
+import 'dart:ui';
+
+import 'package:google_adsense/google_adsense.dart';
+import 'package:web/web.dart' as web;
+
+typedef VoidFn = void Function();
 
 // window.adsbygoogle uses "duck typing", so let us set anything to it.
 @JS('adsbygoogle')
@@ -15,7 +21,7 @@ external set _adsbygoogle(JSAny? value);
 /// Mocks `adsbygoogle` [push] function.
 ///
 /// `push` will run in the next tick (`Timer.run`) to ensure async behavior.
-void mockAdsByGoogle(void Function() push) {
+void mockAdsByGoogle(VoidFn push) {
   _adsbygoogle = <String, Object>{
     'push': () {
       Timer.run(push);
@@ -26,4 +32,59 @@ void mockAdsByGoogle(void Function() push) {
 /// Sets `adsbygoogle` to null.
 void clearAdsByGoogleMock() {
   _adsbygoogle = null;
+}
+
+typedef MockAdConfig = ({Size size, String adStatus});
+
+/// Returns a function that generates a "push" function for [mockAdsByGoogle].
+VoidFn mockAd({
+  Size size = Size.zero,
+  String adStatus = AdStatus.FILLED,
+}) {
+  return mockAds(
+    <MockAdConfig>[(size: size, adStatus: adStatus)],
+  );
+}
+
+/// Returns a function that handles a bunch of ad units at once. Can be used with [mockAdsByGoogle].
+VoidFn mockAds(List<MockAdConfig> adConfigs) {
+  return () {
+    final List<web.HTMLElement> foundTargets =
+        web.document.querySelectorAll('div[id^=adUnit] ins').toList;
+
+    for (int i = 0; i < foundTargets.length; i++) {
+      final web.HTMLElement adTarget = foundTargets[i];
+      if (adTarget.children.length > 0) {
+        continue;
+      }
+
+      final (:Size size, :String adStatus) = adConfigs[i];
+
+      final web.HTMLElement fakeAd = web.HTMLDivElement()
+        ..style.width = '${size.width}px'
+        ..style.height = '${size.height}px'
+        ..style.background = '#fabada';
+
+      // AdSense seems to be setting the width/height on the `ins` of the injected ad too.
+      adTarget
+        ..style.width = '${size.width}px'
+        ..style.height = '${size.height}px'
+        ..style.display = 'block'
+        ..appendChild(fakeAd)
+        ..setAttribute('data-ad-status', adStatus);
+    }
+  };
+}
+
+extension on web.NodeList {
+  List<web.HTMLElement> get toList {
+    final List<web.HTMLElement> result = <web.HTMLElement>[];
+    for (int i = 0; i < length; i++) {
+      final web.Node? node = item(i);
+      if (node != null && node.isA<web.HTMLElement>()) {
+        result.add(node as web.HTMLElement);
+      }
+    }
+    return result;
+  }
 }

--- a/packages/google_adsense/example/web/index.html
+++ b/packages/google_adsense/example/web/index.html
@@ -5,19 +5,6 @@ found in the LICENSE file. -->
 <!DOCTYPE html>
 <html>
 <head>
-  <!--
-    If you are serving your web app in a path other than the root, change the
-    href value below to reflect the base path you are serving from.
-
-    The path provided below has to start and end with a slash "/" in order for
-    it to work correctly.
-
-    For more details:
-    * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
-
-    This is a placeholder for base href that will be replaced by the value of
-    the `--base-href` argument provided to `flutter build`.
-  -->
   <base href="$FLUTTER_BASE_HREF">
 
   <meta charset="UTF-8">
@@ -37,6 +24,9 @@ found in the LICENSE file. -->
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
-  <script src="flutter_bootstrap.js" async></script>
+  <script>
+    /* Inline the contents of flutter_bootstrap.js */
+    {{flutter_bootstrap_js}}
+  </script>
 </body>
 </html>

--- a/packages/google_adsense/lib/src/ad_unit_widget.dart
+++ b/packages/google_adsense/lib/src/ad_unit_widget.dart
@@ -118,11 +118,7 @@ class _AdUnitWidgetWebState extends State<AdUnitWidget>
               target.offsetHeight.toDouble(),
             ));
           } else {
-            // Prevent scrolling issues over empty ad slot
-            target
-              ..style.pointerEvents = 'none'
-              ..style.height = '0px'
-              ..style.width = '0px';
+            // This removes the platform view.
             _updateWidgetSize(Size.zero);
           }
         }


### PR DESCRIPTION
Updated the integration tests to match the new behavior, the problem was that we were not passing the `adFormat` to some of the tests, and the widget in the test was using the maxHeight of its parent element (in this case, the whole app), instead of what we expected.

I've fixed that, and added a test to handle multiple ads added to the app by adsense (some filled, others unfilled).

(Also remove the code that resized the target of the ad right before the platform view was removed from the page.)
